### PR TITLE
Makefiles: allow passing in build parameters and generate image in new namespace

### DIFF
--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -4,7 +4,7 @@ DISTRO_SUFFIX=-$(DISTRO)
 default: build
 
 .PHONY: build
-build: export IMAGE_LOCATION ?= quay.io/unleashed
+build: export IMAGE_LOCATION ?= quay.io/3scale
 build: export IMAGE_NAME ?= rbenv4ci-container
 build: export VERSION ?= $(shell git describe --dirty)
 build: export IMAGE_VERSION := $(VERSION)$(DISTRO_SUFFIX)
@@ -28,7 +28,7 @@ build:
 	docker rm dummy-export-$(IMAGE_NAME)-$(IMAGE_VERSION)
 
 .PHONY: destroy-layered
-destroy-layered: export IMAGE_LOCATION ?= quay.io/unleashed
+destroy-layered: export IMAGE_LOCATION ?= quay.io/3scale
 destroy-layered: export IMAGE_NAME ?= rbenv4ci-container
 destroy-layered: export VERSION ?= $(shell git describe --dirty)
 destroy-layered: export IMAGE_VERSION := $(VERSION)$(DISTRO_SUFFIX)
@@ -37,7 +37,7 @@ destroy-layered:
 	-docker rmi $(IMAGE_FULL_NAME):$(IMAGE_VERSION)-layered
 
 .PHONY: destroy
-destroy: export IMAGE_LOCATION ?= quay.io/unleashed
+destroy: export IMAGE_LOCATION ?= quay.io/3scale
 destroy: export IMAGE_NAME ?= rbenv4ci-container
 destroy: export VERSION ?= $(shell git describe --dirty)
 destroy: export IMAGE_VERSION:=$(VERSION)$(DISTRO_SUFFIX)

--- a/alpine/Makefile
+++ b/alpine/Makefile
@@ -12,6 +12,7 @@ build: export CONTAINER_USER ?= ruby
 build: export IMAGE_FULL_NAME := $(IMAGE_LOCATION)/$(IMAGE_NAME)
 build:
 	docker build --rm --build-arg USER_NAME=$(CONTAINER_USER) \
+		$(DOCKER_BUILD_EXTRA_ARGS) \
 		-t $(IMAGE_FULL_NAME):$(IMAGE_VERSION)-layered .
 	-docker rm dummy-export-$(IMAGE_NAME)-$(IMAGE_VERSION)
 	IMAGE_PATH=$$(docker run \

--- a/centos/Makefile
+++ b/centos/Makefile
@@ -4,7 +4,7 @@ DISTRO_SUFFIX=-$(DISTRO)
 default: build
 
 .PHONY: build
-build: export IMAGE_LOCATION ?= quay.io/unleashed
+build: export IMAGE_LOCATION ?= quay.io/3scale
 build: export IMAGE_NAME ?= rbenv4ci-container
 build: export VERSION ?= $(shell git describe --dirty)
 build: export IMAGE_VERSION := $(VERSION)$(DISTRO_SUFFIX)
@@ -27,7 +27,7 @@ build:
 	docker rm dummy-export-$(IMAGE_NAME)-$(IMAGE_VERSION)
 
 .PHONY: destroy-layered
-destroy-layered: export IMAGE_LOCATION ?= quay.io/unleashed
+destroy-layered: export IMAGE_LOCATION ?= quay.io/3scale
 destroy-layered: export IMAGE_NAME ?= rbenv4ci-container
 destroy-layered: export VERSION ?= $(shell git describe --dirty)
 destroy-layered: export IMAGE_VERSION := $(VERSION)$(DISTRO_SUFFIX)
@@ -36,7 +36,7 @@ destroy-layered:
 	-docker rmi $(IMAGE_FULL_NAME):$(IMAGE_VERSION)-layered
 
 .PHONY: destroy
-destroy: export IMAGE_LOCATION ?= quay.io/unleashed
+destroy: export IMAGE_LOCATION ?= quay.io/3scale
 destroy: export IMAGE_NAME ?= rbenv4ci-container
 destroy: export VERSION ?= $(shell git describe --dirty)
 destroy: export IMAGE_VERSION := $(VERSION)$(DISTRO_SUFFIX)

--- a/centos/Makefile
+++ b/centos/Makefile
@@ -12,6 +12,7 @@ build: export CONTAINER_USER ?= ruby
 build: export IMAGE_FULL_NAME := $(IMAGE_LOCATION)/$(IMAGE_NAME)
 build:
 	docker build --rm --build-arg USER_NAME=$(CONTAINER_USER) \
+		$(DOCKER_BUILD_EXTRA_ARGS) \
 		-t $(IMAGE_FULL_NAME):$(IMAGE_VERSION)-layered .
 	-docker rm dummy-export-$(IMAGE_NAME)-$(IMAGE_VERSION)
 	IMAGE_PATH=$$(docker run \


### PR DESCRIPTION
This allows users to invoke `make build` setting `DOCKER_BUILD_EXTRA_ARGS` to any parameters accepted by `docker build`. The `--build-arg ARG=VALUE` one is the most useful in this case, since it allows updating on-demand the versions for the included software, such as rbenv.

While at it, we now generate the image within the quay.io/3scale namespace.